### PR TITLE
feat(naming): prefix filenames with subfolder while preserving structure

### DIFF
--- a/panorama_sfm.py
+++ b/panorama_sfm.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import cv2
+import re
 import numpy as np
 import PIL.ExifTags
 import PIL.Image
@@ -306,6 +307,14 @@ def render_perspective_images(
             )
 
             image_name = rig_config.cameras[cam_idx].image_prefix + pano_name
+            # Prefix file name with numeric subfolder (or folder name) to ensure uniqueness.
+            _img_rel = Path(image_name)
+            folder = _img_rel.parent.name
+            m = re.search(r"(\d+)$", folder)
+            folder_prefix = m.group(1) if m else folder
+            prefixed_name = f"{folder_prefix}_{_img_rel.name}"
+            image_name = str(_img_rel.parent / prefixed_name)
+
             # Build mask name as <image_base>.mask.png, avoiding double extensions like .jpg.png
             _img_rel = Path(image_name)
             mask_rel = _img_rel.parent / f"{_img_rel.stem}.mask.png"

--- a/panorama_sfm.py
+++ b/panorama_sfm.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import cv2
 import re
+import shutil
 import numpy as np
 import PIL.ExifTags
 import PIL.Image
@@ -380,6 +381,26 @@ def run(args):
         override_ref_idx=override_ref_idx,
         export_xmp=bool(getattr(args, 'export_rc_xmp', False)),
     )
+
+    # --- Flatten images and masks for RealityCapture ---
+    try:
+        rc_dir = args.output_path / "RC"
+        rc_dir.mkdir(exist_ok=True, parents=True)
+        img_count = 0
+        mask_count = 0
+        # Copy images (flat)
+        for p in image_dir.rglob("*"):
+            if p.is_file():
+                shutil.copy2(p, rc_dir / p.name)
+                img_count += 1
+        # Copy masks (flat)
+        for p in mask_dir.rglob("*"):
+            if p.is_file():
+                shutil.copy2(p, rc_dir / p.name)
+                mask_count += 1
+        logging.info(f"RC export: copied {img_count} images and {mask_count} masks into {rc_dir}")
+    except Exception as e:
+        logging.warning(f"RC export step failed: {e}")
 
     pycolmap.set_random_seed(0)
 


### PR DESCRIPTION
- Prefix rendered image filenames with their immediate subfolder (e.g., images/0/0_IMG.jpg) to ensure uniqueness
- Update mask naming and mask_list accordingly; keep folder structure unchanged
- Add legacy COLMAP masks under output/colmap_masks and use reader_options mask_path for compatibility
- Remove previous RC flattening step