### PR TITLE
feat(gui): selectable output root

### DIFF
--- a/delete_pano0.py
+++ b/delete_pano0.py
@@ -16,11 +16,15 @@ def delete_all_pano_camera0(source_dir: Path):
         print(f"✅ Deleted {deleted_folders} 'pano_camera0' folder(s).")
 
 if __name__ == "__main__":
-    # If an argument is provided, treat it as the project root (the folder you dropped).
-    # We’ll delete <project_root>/output/images/**/pano_camera0
+    # If an argument is provided, try to interpret it as an output root
+    # Preferred: <output_root>/images
+    # Fallback: treat as project_root and use <project_root>/output/images
     if len(sys.argv) >= 2:
-        project_root = Path(sys.argv[1]).resolve()
-        source = project_root / "output" / "images"
+        root = Path(sys.argv[1]).resolve()
+        if (root / "images").exists():
+            source = root / "images"
+        else:
+            source = root / "output" / "images"
     else:
         # Fallback: current-dir/output/images (original behavior)
         source = Path("output/images").resolve()

--- a/segment_images.py
+++ b/segment_images.py
@@ -1,11 +1,12 @@
 import os
+import sys
 import shutil
 from pathlib import Path
 from collections import defaultdict
 
 # === CONFIGURATION ===
-SOURCE_DIR = Path("output/images")      # Where COLMAP's images are
-DEST_DIR = Path("output/Segment_images")       # Where segmented groups go
+DEFAULT_SOURCE_DIR = Path("output/images")      # Default where COLMAP's images are
+DEFAULT_DEST_DIR = Path("output/Segment_images")       # Default where segmented groups go
 VALID_EXTENSIONS = {".jpg", ".jpeg", ".png"}  # Add/remove if needed
 
 def get_prefix(filename):
@@ -53,6 +54,15 @@ def delete_all_pano_camera0(source_dir):
         print(f"🗑️  Deleted {deleted_folders} 'pano_camera0' folders.")
 
 if __name__ == "__main__":
-    segments = collect_segment_images(SOURCE_DIR)
-    copy_segments(segments, DEST_DIR)
-    delete_all_pano_camera0(SOURCE_DIR)
+    # Optional first argument: output_root (expects images under <output_root>/images)
+    if len(sys.argv) >= 2:
+        output_root = Path(sys.argv[1]).resolve()
+        src = output_root / "images"
+        dst = output_root / "Segment_images"
+    else:
+        src = DEFAULT_SOURCE_DIR
+        dst = DEFAULT_DEST_DIR
+
+    segments = collect_segment_images(src)
+    copy_segments(segments, dst)
+    delete_all_pano_camera0(src)


### PR DESCRIPTION
- Add output folder picker in the GUI (defaults to <project>/output)
- Pass --output_path to wrapper so panorama_sfm writes under the chosen root
- Pass output_root to delete_pano0.py and segment_images.py; update scripts to accept it
- No changes to camera logic or COLMAP masking pipeline