### PR TITLE
Adjust no-masking angle offsets

### DIFF
--- a/run_gui.py
+++ b/run_gui.py
@@ -40,12 +40,12 @@ NO_MASKING_PITCH_YAW_PAIRS = [
     (0, 90),   # Reference Pose (ref_idx = 0)
     (32, 0),
     (-42, 0),
-    (0, 42),
+    (0, 33),  # hay que bajarlo de 42 
     (0, -25),
     (42, 180),
     (-32, 180),
     (0, 205),
-    (0, 138),
+    (0, 142), # hay que subirlo de 138
 ]
 NO_MASKING_REF_IDX = 0
 


### PR DESCRIPTION
## Summary
- tune the no-masking yaw preset from 42 to 33 for better reference coverage
- increase the high yaw preset from 138 to 142 to match new adjustments

## Testing
- not run